### PR TITLE
Enhance exception handling and update version number

### DIFF
--- a/src/ResponseCrafter/HttpExceptions/BadRequestException.cs
+++ b/src/ResponseCrafter/HttpExceptions/BadRequestException.cs
@@ -25,6 +25,14 @@ public class BadRequestException : ApiException
       }
    }
 
+   public static void ThrowIfNull([NotNull] object? value, string exceptionMessage, Dictionary<string, string>? errors = null) 
+   {
+      if (value is null)
+      {
+         throw new BadRequestException(exceptionMessage, errors);
+      }
+   }
+
    public static void ThrowIfNullOrEmpty([NotNull] IEnumerable? value, string exceptionMessage)
    {
       // ReSharper disable once GenericEnumeratorNotDisposed
@@ -32,6 +40,15 @@ public class BadRequestException : ApiException
                                  .MoveNext())
       {
          throw new BadRequestException(exceptionMessage);
+      }
+   }
+
+   public static void ThrowIfNullOrEmpty([NotNull] IEnumerable? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (value is null || !value.GetEnumerator()
+                                 .MoveNext())
+      {
+         throw new BadRequestException(exceptionMessage, errors);
       }
    }
 
@@ -43,6 +60,14 @@ public class BadRequestException : ApiException
       }
    }
 
+   public static void ThrowIfNullOrWhiteSpace([NotNull] string? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (string.IsNullOrWhiteSpace(value))
+      {
+         throw new BadRequestException(exceptionMessage, errors);
+      }
+   }
+
    public static void ThrowIf(bool condition, string exceptionMessage)
    {
       if (condition)
@@ -51,11 +76,27 @@ public class BadRequestException : ApiException
       }
    }
 
+   public static void ThrowIf(bool condition, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (condition)
+      {
+         throw new BadRequestException(exceptionMessage, errors);
+      }
+   }
+
    public static void ThrowIfNullOrNegative([NotNull] decimal? value, string exceptionMessage)
    {
       if (value is < 0 or null)
       {
          throw new BadRequestException(exceptionMessage);
+      }
+   }
+
+   public static void ThrowIfNullOrNegative([NotNull] decimal? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (value is < 0 or null)
+      {
+         throw new BadRequestException(exceptionMessage, errors);
       }
    }
 }

--- a/src/ResponseCrafter/HttpExceptions/InternalServerErrorException.cs
+++ b/src/ResponseCrafter/HttpExceptions/InternalServerErrorException.cs
@@ -25,6 +25,14 @@ public class InternalServerErrorException : ApiException
       }
    }
 
+   public static void ThrowIfNull([NotNull] object? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (value is null)
+      {
+         throw new InternalServerErrorException(exceptionMessage, errors);
+      }
+   }
+
    public static void ThrowIfNullOrEmpty([NotNull] IEnumerable? value, string exceptionMessage)
    {
       // ReSharper disable once GenericEnumeratorNotDisposed
@@ -32,6 +40,15 @@ public class InternalServerErrorException : ApiException
                                  .MoveNext())
       {
          throw new InternalServerErrorException(exceptionMessage);
+      }
+   }
+
+   public static void ThrowIfNullOrEmpty([NotNull] IEnumerable? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (value is null || !value.GetEnumerator()
+                                 .MoveNext())
+      {
+         throw new InternalServerErrorException(exceptionMessage, errors);
       }
    }
 
@@ -43,6 +60,13 @@ public class InternalServerErrorException : ApiException
       }
    }
 
+   public static void ThrowIfNullOrWhiteSpace([NotNull] string? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (string.IsNullOrWhiteSpace(value))
+      {
+         throw new InternalServerErrorException(exceptionMessage, errors);
+      }
+   }
 
    public static void ThrowIf(bool condition, string exceptionMessage)
    {
@@ -52,11 +76,25 @@ public class InternalServerErrorException : ApiException
       }
    }
 
+   public static void ThrowIf(bool condition, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (condition)
+      {
+         throw new InternalServerErrorException(exceptionMessage, errors);
+      }
+   }
    public static void ThrowIfNullOrNegative([NotNull] decimal? value, string exceptionMessage)
    {
       if (value is < 0 or null)
       {
          throw new InternalServerErrorException(exceptionMessage);
+      }
+   }
+   public static void ThrowIfNullOrNegative([NotNull] decimal? value, string exceptionMessage, Dictionary<string, string>? errors = null)
+   {
+      if (value is < 0 or null)
+      {
+         throw new BadRequestException(exceptionMessage, errors);
       }
    }
 }

--- a/src/ResponseCrafter/ResponseCrafter.csproj
+++ b/src/ResponseCrafter/ResponseCrafter.csproj
@@ -8,7 +8,7 @@
         <Copyright>MIT</Copyright>
         <PackageIcon>pandatech.png</PackageIcon>
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
-        <Version>5.1.10</Version>
+        <Version>5.1.11</Version>
         <PackageId>Pandatech.ResponseCrafter</PackageId>
         <PackageTags>Pandatech, library, exception handler, exception, middleware, Api response</PackageTags>
         <Title>ResponseCrafter</Title>


### PR DESCRIPTION
Updated `BadRequestException` and `InternalServerErrorException` classes to include overloads for static methods with an optional `Dictionary<string, string>? errors` parameter. This allows for more detailed error handling in methods like `ThrowIfNull`, `ThrowIfNullOrEmpty`, `ThrowIfNullOrWhiteSpace`, `ThrowIf`, and `ThrowIfNullOrNegative`.

Incremented version number in `ResponseCrafter.csproj` from `5.1.10` to `5.1.11` and made a minor formatting adjustment in the `<ItemGroup>` section.